### PR TITLE
Add multi-bucket property

### DIFF
--- a/jobs/encrypt-blobstore/spec
+++ b/jobs/encrypt-blobstore/spec
@@ -13,8 +13,8 @@ templates:
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
 properties:
-  encrypt-blobstore.bucket:
-    description: AWS Bucket Name
+  encrypt-blobstore.buckets:
+    description: AWS Bucket Names
   encrypt-blobstore.access_key:
     description: AWS Access Key
   encrypt-blobstore.secret_access_key:

--- a/jobs/encrypt-blobstore/templates/bin/encrypt-blobstore.sh.erb
+++ b/jobs/encrypt-blobstore/templates/bin/encrypt-blobstore.sh.erb
@@ -6,7 +6,6 @@ export AWS_ACCESS_KEY_ID="<%= p('encrypt-blobstore.access_key') %>"
 export AWS_SECRET_ACCESS_KEY="<%= p('encrypt-blobstore.secret_access_key') %>"
 
 AWS_PATH=/var/vcap/packages/aws-cli/bin/aws
-BUCKET="<%= p('encrypt-blobstore.bucket') %>"
 BLOBS=`${AWS_PATH} s3 ls s3://${BUCKET} | tr -s ' ' | cut -f4- -d' '`
 ENCRYPTION_TYPE="<%= p('encrypt-blobstore.encryption_type') %>"
 

--- a/jobs/encrypt-blobstore/templates/config/encrypt-blobstore.erb
+++ b/jobs/encrypt-blobstore/templates/config/encrypt-blobstore.erb
@@ -1,3 +1,4 @@
 # m h dom mon dow user  command
-* 0 * * * root /var/vcap/jobs/encrypt-blobstore/bin/encrypt-blobstore.sh
-
+<% p('encrypt-blobstore.buckets').each do |bucket| %>
+* 0 * * * root BUCKET="<%= bucket %>" /var/vcap/jobs/encrypt-blobstore/bin/encrypt-blobstore.sh
+<% end %>

--- a/templates/encrypt-blobstore.yml
+++ b/templates/encrypt-blobstore.yml
@@ -3381,7 +3381,10 @@ properties:
   encrypt-blobstore:
     localpass: test
     sitepass: test
-    bucket: foo
+    buckets:
+    - "bucketName"
+    - "bucketName2"
+    - "bucketName3"
     access_key: far
     secret_access_key: fyz
 


### PR DESCRIPTION
~~This patch series is a work in progress.~~

The work in this patch series should cover the remaining hurdles @sharms and I brought up on 18F/cg-atlas#23 ( and the defunct 18F/cg-atlas#28 ) around allowing for multiple buckets to be referenced in [`monitoring.yml` in 18F/cg-deploy-monitoring](https://github.com/18F/cg-deploy-monitoring/blob/3239d4752b66097336bef13f7c24654b6984fe9d/monitoring.yml#L93-L94).

~~Commits prefixed with `[d]` will be removed from this branch before this PR is ready to be merged in. Those are there just for my local `bosh-lite` instance.~~
