### PR TITLE
Add in base documentation files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## Welcome!
+
+We're so glad you're thinking about contributing to an 18F open source project!
+If you're unsure about anything, just ask -- or submit the issue or pull request
+anyway. The worst that can happen is you'll be politely asked to change
+something. We love all friendly contributions.
+
+We want to ensure a welcoming environment for all of our projects. Our staff
+follow the [18F Code of Conduct][18f-coc] and all contributors should do the same.
+
+We encourage you to read this project's CONTRIBUTING policy (you are here), its
+[LICENSE](LICENSE.md), and its [README](README.md).
+
+If you have any questions or want to read more, check out the [18F Open Source
+Policy GitHub repository]( https://github.com/18f/open-source-policy), or just
+[shoot us an email](mailto:18f@gsa.gov).
+
+## Public domain
+
+This project is in the public domain within the United States, and
+copyright and related rights in the work worldwide are waived through
+the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All contributions to this project will be released under the CC0
+dedication. By submitting a pull request, you are agreeing to comply
+with this waiver of copyright interest.
+
+[18f-coc]: https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md "18F Code of Conduct"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,32 @@
+As a work of the United States Government, this project is in the
+public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work
+worldwide through the CC0 1.0 Universal public domain dedication.
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full
+text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the
+extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0,
+nor are the rights that other persons may have in the work or in how the
+work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with
+this deed makes no warranties about the work, and disclaims liability for
+all uses of the work, to the fullest extent permitted by applicable law.
+When using or citing the work, you should not imply endorsement by the
+author or the affirmer.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Encrypt s3 Blobstores
+
+This boshrelease creates cron jobs to encrypt s3 blobstores using the `aws-cli`.
+
+It's dependencies are:
+
+- `aws-cli`
+- `Python 2.7.8`
+
+## Public domain
+
+This project is in the worldwide public domain. As stated in CONTRIBUTING:
+
+> This project is in the public domain within the United States, and copyright
+> and related rights in the work worldwide are waived through the CC0 1.0
+> Universal public domain dedication.
+
+All contributions to this project will be released under the CC0 dedication. By
+submitting a pull request, you are agreeing to comply with this waiver of
+copyright interest.


### PR DESCRIPTION
These base files were generated via `18f-cli` and tweaked to match the repo.

**Sidenote**: I generated some `*.patch` files for these commits to easily apply this across all the `boshrelease` repos that might be missing them, if there's any interest in that later. [Those files are here](https://gist.github.com/rogeruiz/9e4aaff98658fc816d104ba5ab5da33b).
