### PR TITLE
Recurse S3 tree

### DIFF
--- a/jobs/encrypt-blobstore/templates/bin/encrypt-blobstore.sh.erb
+++ b/jobs/encrypt-blobstore/templates/bin/encrypt-blobstore.sh.erb
@@ -7,7 +7,7 @@ export AWS_ACCESS_KEY_ID="<%= p('encrypt-blobstore.access_key') %>"
 export AWS_SECRET_ACCESS_KEY="<%= p('encrypt-blobstore.secret_access_key') %>"
 
 AWS_PATH=/var/vcap/packages/aws-cli/bin/aws
-BLOBS=`${AWS_PATH} s3 ls s3://${BUCKET} | tr -s ' ' | cut -f4- -d' '`
+BLOBS=`${AWS_PATH} s3 ls --recursive s3://${BUCKET} | tr -s ' ' | cut -f4- -d' '`
 ENCRYPTION_TYPE="<%= p('encrypt-blobstore.encryption_type') %>"
 
 for blob in $BLOBS; do


### PR DESCRIPTION
- Trees deeper than 1 level failed due to prefix 'PRE'
- Recursing concats path to single string
